### PR TITLE
Use relative path for application helper

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -17,7 +17,7 @@ component {
 	// Entry Point
 	this.entryPoint 		= "cbsecurity";
 	// Helpers
-	this.applicationHelper 	= [ "/cbsecurity/helpers/mixins.cfm" ];
+	this.applicationHelper 	= [ "helpers/mixins.cfm" ];
 	// Dependencies
 	this.dependencies 		= [ "cbauth", "jwt" ];
 


### PR DESCRIPTION
Fixes issue where exception is thrown when sessionStartHandler event is fired.