### PR TITLE
Don't trigger ColdBox's invalid event looping protection

### DIFF
--- a/interceptors/Security.cfc
+++ b/interceptors/Security.cfc
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright since 2016 by Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
@@ -227,9 +227,12 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 		required currentEvent
 	){
 		// Get handler bean for the current event
-		var handlerBean = variables.handlerService.getHandlerBean( arguments.event.getCurrentEvent() );
+        var handlerBean = variables.handlerService.getHandlerBean( arguments.event.getCurrentEvent() );
 		
-		if ( isInvalidEventHandlerBean( handlerBean ) ) {
+		if ( 
+            listGetAt( controller.getColdboxSettings().version, 1, "." ) == 5 && 
+            isInvalidEventHandlerBean( handlerBean ) 
+        ) {
             // ColdBox tries to detect invalid event handler loops by keeping
             // track of the last invalid event to fire.  If that invalid event
             // fires twice, it throws a hard exception to prevent infinite loops.

--- a/test-harness/tests/specs/unit/SecurityTest.cfc
+++ b/test-harness/tests/specs/unit/SecurityTest.cfc
@@ -13,8 +13,14 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
 				// setup properties
 				setup();
 				variables.wirebox = new coldbox.system.ioc.Injector();
-				mockController.$( "getAppHash", hash( "appHash" ) ).$( "getAppRootPath", expandPath( "/root" ) );
-				security = interceptor;
+                mockController
+                    .$( "getAppHash", hash( "appHash" ) )
+                    .$( "getAppRootPath", expandPath( "/root" ) )
+                    .$( "getColdboxSettings", {
+                        "version": "6.0.0"
+                    }, false  );
+                security = interceptor;
+                security.setInvalidEventHandler( '' );
 				settings = {
 					// The global invalid authentication event or URI or URL to go if an invalid authentication occurs
 					"invalidAuthenticationEvent"  : "",
@@ -131,7 +137,32 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
 				expect( function(){
 					security.configure();
 				} ).toThrow( "Security.ValidatorMethodException" );
-			} );
+            } );
+
+            it( "does not enable invalid event handler processing on Coldbox versions 6+", function() {
+                security.setProperties( settings );
+				security
+					.$( "getInstance" )
+					.$args( settings.validator )
+					.$results( wirebox.getInstance( settings.validator ) );
+				security.configure();
+				expect( security.$getProperty( "enableInvalidHandlerCheck" ) ).toBeFalse();
+            } );
+            
+            it( "enables invalid event handler processing on Coldbox versions prior to 6", function() {
+                
+                mockController.$( "getColdboxSettings", {
+                    "version": "5.0.0"
+                }, false  );
+                
+                security.setProperties( settings );
+				security
+					.$( "getInstance" )
+					.$args( settings.validator )
+					.$results( wirebox.getInstance( settings.validator ) );
+				security.configure();
+				expect( security.$getProperty( "enableInvalidHandlerCheck" ) ).toBeTrue();
+            } );   
 
 			describe( "It can load many types of rules", function(){
 				beforeEach( function(currentSpec){
@@ -173,7 +204,8 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
 
 					expect( security.getProperty( "rules", [] ) ).toHaveLength( 1 );
 				} );
-			} );
+            } );
+            
 		} );
 	}
 


### PR DESCRIPTION
This is the same fix that @elpete implemented in cbGuard for an issue I reported where introducing cbSecurity or cbGuard to an app would break the `invalidEventHandler` Coldbox setting,  See here for details: https://github.com/coldbox-modules/cbguard/issues/15