### PR TITLE
Fix: Ensure non-configured rules default to empty array

### DIFF
--- a/models/util/RulesLoader.cfc
+++ b/models/util/RulesLoader.cfc
@@ -63,6 +63,7 @@ component accessors="true" singleton {
 	 */
 	function rulesSourceChecks( required settings ){
 		param arguments.settings.rulesSource = "";
+		param arguments.settings.rules = [];
 
 		// Auto detect rules source
 		if ( isSimpleValue( arguments.settings.rules ) ) {


### PR DESCRIPTION
If a developer declines to set a value for
`moduleSettings.cbSecurity.rules` when configuring cbSecurity, they get an error:

```
Element SETTINGS.RULES is undefined in ARGUMENTS.
```

IMHO, this is a failure on Coldbox's part to properly merge the
dev-defined coldbox `moduleSettings.cbSecurity` struct with cbSecurity's
own `settings` struct. Regardless, I'd expect the `rules` array to
default to an empty array _[as documented](https://coldbox-security.ortusbooks.com/getting-started/first-chapter)_.