### PR TITLE
fix: Correct validator interface error message

### DIFF
--- a/interceptors/Security.cfc
+++ b/interceptors/Security.cfc
@@ -460,7 +460,7 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 			variables.validator = arguments.validator;
 		} else {
 			throw(
-				message = "Validator object does not have a 'userValidator()' and `annotationValidator()' methods. I can only register objects with these interface methods.",
+				message = "Validator object requires either a 'ruleValidator()' or `annotationValidator()' method. I can only register objects with these interface methods.",
 				type    = "Security.ValidatorMethodException"
 			);
 		}


### PR DESCRIPTION
The `userValidator()` method has been changed to `roleValidator()`, but the error message was forgotten! So the developer is told they need a `userValidator()` method... because the `userValidator` method is no longer supported. :/ 