### PR TITLE
Fix: Correct typo in configured interception point

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -110,7 +110,7 @@ component {
 			customInterceptionPoints = [
 				// Validator Events
 				"cbSecurity_onInvalidAuthentication",
-				"cbSecurity_onInvalidAuhtorization",
+				"cbSecurity_onInvalidAuthorization",
 				// JWT Events
 				"cbSecurity_onJWTCreation",
 				"cbSecurity_onJWTInvalidation",


### PR DESCRIPTION
Fixes a typo in the `cbSecurity_onInvalidAuthorization` interception point declaration. Previously, the typo would prevent ColdBox from allowing the correctly-typed interception point from ever triggering an interception listener.