### PR TITLE
feat: Add support for JSON/XML/model rules source when loading rules …

### DIFF
--- a/interceptors/Security.cfc
+++ b/interceptors/Security.cfc
@@ -99,11 +99,19 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 		param arguments.settings.defaultAuthorizationAction  = "";
 		param arguments.settings.validator                   = "";
 
+		// Verify setting configurations
+		variables.rulesLoader.rulesSourceChecks( arguments.settings );
+
 		// Store configuration in this firewall
 		variables.securityModules[ arguments.module ] = arguments.settings;
 
 		// Process Module Rules
 		arguments.settings.rules = variables.rulesLoader.normalizeRules( arguments.settings.rules, module );
+
+		// Load Rules if we have a ruleSource
+		if ( arguments.settings.rulesSource.len() ) {
+			arguments.settings.rules = variables.rulesLoader.loadRules( arguments.settings );
+		}
 
 		// prepend them so the don't interfere with MAIN rules
 		// one by one as I don't see a way to prepend the whole array at once

--- a/test-harness/tests/specs/unit/SecurityTest.cfc
+++ b/test-harness/tests/specs/unit/SecurityTest.cfc
@@ -204,7 +204,55 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
 
 					expect( security.getProperty( "rules", [] ) ).toHaveLength( 1 );
 				} );
-            } );
+			} );
+			
+			describe( "module setting load", function() {
+				beforeEach( function(currentSpec){
+					settings.rules = [];
+					settings.validator = "tests.resources.security";
+					security.$property( propertyName = "securityModules", mock = {} );
+					security.$property( propertyName = "log", mock = { info : function() {} });
+					security
+						.$( "getInstance" )
+						.$args( settings.validator )
+						.$results( wirebox.getInstance( settings.validator ) );
+					security.setProperties( settings );
+				} );
+
+				it( "can load JSON Rules based on module settings", function(){
+					expect( security.getProperty( "rules", [] ) ).toHaveLength( 0 );
+					var source = expandPath( "/tests/resources/security.json.cfm" );
+					mockController.$( "locateFilePath", source );
+
+					// initiate cbSecurity's module registration rule parsing
+					security.registerModule( "myTestModule", { rules : source } );
+
+					expect( security.getProperty( "rules", [] ) ).toHaveLength( 2 );
+				} );
+
+				it( "can load XML Rules based on module settings", function(){
+					var source   = expandPath( "/tests/resources/security.xml.cfm" );
+					mockController.$( "locateFilePath", source );
+
+					// initiate cbSecurity's module registration rule parsing
+					security.registerModule( "myTestModule", { rules : source } );
+
+					expect( security.getProperty( "rules", [] ) ).toHaveLength( 3 );
+				} );
+
+				it( "can load model Rules based on module settings", function(){
+					var moduleSettings = {
+						rules           : "model",
+						rulesModel      : "tests.resources.security",
+						rulesModelMethod: "getSecurityRules"
+					};
+
+					// initiate cbSecurity's module registration rule parsing
+					security.registerModule( "myTestModule", moduleSettings );
+
+					expect( security.getProperty( "rules", [] ) ).toHaveLength( 1 );
+				} );
+			});
             
 		} );
 	}


### PR DESCRIPTION
…from module settings

The current syntax for module cbsecurity rules only appears to support a `rules[]` array when pulling `cbSecurity` module settings from the module's `settings` struct. (See [module rules documentation](https://coldbox-security.ortusbooks.com/getting-started/first-chapter/rule-sources/module-rules) for example.)

This commit adds support for full JSON/XML/model rules so folks can use their rule syntax of choice in module configurations.

For example, the following now works to pull in rules from `#modulePath#/config/security.json.cfm`:

```js
// modules_app/myModule/ModuleConfig.cfc
settings = {
	// CB Security Rules to append to global rules
	cbsecurity = {
		"rules"	: "#modulePath#/config/security.json.cfm"
	}
};
```

Previously, this would throw an error: `The RULES argument passed to the normalizeRules function is not of type array`, precisely because only an `array` of rules was supported or expected in cbSecurity configuration pulled from a module.