### PR TITLE
Fix(visualizer): Fix ACF18 syntax error in settings visualizer

### DIFF
--- a/views/home/settings.cfm
+++ b/views/home/settings.cfm
@@ -1,17 +1,21 @@
+<cfscript>
+	globalSettings = prc.properties.filter( function( key ){
+		return !listFindNoCase( "rules,jwt", key );
+	} );
+	jwtSettings = prc.properties.jwt.filter( function( key ){
+		return !listFindNoCase( "secretKey", key );
+	} );
+</cfscript>
 <cfoutput>
 <div class="mt-2">
 
 	<p>Here is a listing of the settings for the global interceptor <code>cbsecurity@global</code>:</p>
 
-	<cfdump var="#prc.properties.filter( function( key ){
-		return !listFindNoCase( "rules,jwt", key );
-	} )#">
+	<cfdump var="#globalSettings#">
 
 	<h2>JWT Settings</h2>
 	<p>Here are your settings for your Json Web Tokens Security. Please note your <code>secretKey</code> is not shown.</p>
-	<cfdump var="#prc.properties.jwt.filter( function( key ){
-		return !listFindNoCase( "secretKey", key );
-	} )#">
+	<cfdump var="#jwtSettings#">
 
 </div>
 </cfoutput>


### PR DESCRIPTION
This PR fixes a syntax error when attempting to use the visualizer in ACF 2018.

![Screenshot from 2020-12-14 14-07-21](https://user-images.githubusercontent.com/8106227/102124168-f0caf400-3e15-11eb-9753-f5c784df630e.png)
