### PR TITLE
Patch/default validator auth service

### DIFF
--- a/models/validators/CBAuthValidator.cfc
+++ b/models/validators/CBAuthValidator.cfc
@@ -8,7 +8,7 @@
 component singleton {
 
 	// Injection
-	property name="cbauth" inject="authenticationService@cbauth";
+	property name="cbSecurity" inject="CBSecurity@cbSecurity";
 
 	/**
 	 * This function is called once an incoming event matches a security rule.
@@ -54,10 +54,10 @@ component singleton {
 		};
 
 		// Are we logged in?
-		if ( variables.cbauth.isLoggedIn() ) {
+		if ( variables.cbSecurity.getAuthService().isLoggedIn() ) {
 			// Do we have any permissions?
 			if ( listLen( arguments.permissions ) ) {
-				results.allow = variables.cbauth.getUser().hasPermission( arguments.permissions );
+				results.allow = variables.cbSecurity.getAuthService().getUser().hasPermission( arguments.permissions );
 				results.type  = "authorization";
 			} else {
 				// We are satisfied!

--- a/test-harness/tests/specs/unit/SecurityTest.cfc
+++ b/test-harness/tests/specs/unit/SecurityTest.cfc
@@ -18,7 +18,13 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
                     .$( "getAppRootPath", expandPath( "/root" ) )
                     .$( "getColdboxSettings", {
                         "version": "6.0.0"
-                    }, false  );
+					}, false  );
+					
+				mockController
+					.$( "getSetting" )
+					.$args( "modules" )
+					.$results( [] );
+
                 security = interceptor;
                 security.setInvalidEventHandler( '' );
 				settings = {
@@ -114,7 +120,8 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
 					.$args( settings.validator )
 					.$results( wirebox.getInstance( settings.validator ) );
 
-				security.configure();
+				security.afterAspectsLoad();
+
 				expect(
 					security.getValidator(
 						createMock( "coldbox.system.web.context.RequestContext" ).$( "getCurrentModule", "" )
@@ -135,7 +142,7 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbse
 					.$results( createStub() );
 
 				expect( function(){
-					security.configure();
+					security.afterAspectsLoad();
 				} ).toThrow( "Security.ValidatorMethodException" );
             } );
 


### PR DESCRIPTION
1. Respect the `authenticationService` setting from within `cbAuthValidator` so we can actually use our own `AuthenticationService` cfc without also needing to write our own validator.
2. Fix the tests for validator load. Looks like they were broken when we moved `registerValidator()` from `configure()` to `afterAspectsLoad()`.