### PR TITLE
prevent arrayWrap from erring if items is a bool

### DIFF
--- a/models/CBSecurity.cfc
+++ b/models/CBSecurity.cfc
@@ -416,7 +416,7 @@ component singleton accessors="true" {
 	 * @items One, a list or an array
 	 */
 	private function arrayWrap( required items ){
-		return isArray( arguments.items ) ? items : items.listToArray();
+		return isArray( arguments.items ) ? items : listToArray( items );
 	}
 
 }


### PR DESCRIPTION
I was using this function to try and make another improvement and ran into a boolean where boolean.listToArray() errors.
This is a safer version, although, not as cool as a member function.