### PR TITLE
Fix getRealIP() to only return originating user's source IP

### DIFF
--- a/interceptors/Security.cfc
+++ b/interceptors/Security.cfc
@@ -737,7 +737,7 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 			return headers[ "X-Forwarded-For" ];
 		}
 
-		return len( CGI.REMOTE_ADDR ) ? CGI.REMOTE_ADDR : "127.0.0.1";
+		return len( CGI.REMOTE_ADDR ) ? trim( listFirst( CGI.REMOTE_ADDR ) ) : "127.0.0.1";
 	}
 
 	/**


### PR DESCRIPTION
If we end up with a list of IP addresses, then we only want the first one which will be the requesting user's IP.