### PR TITLE
Add a secureSameUser method to throw when passed a different user

### DIFF
--- a/models/CBSecurity.cfc
+++ b/models/CBSecurity.cfc
@@ -258,9 +258,33 @@ component singleton accessors="true" {
 		}
 		if ( results ) {
 			throw( type = "NotAuthorized", message = arguments.message );
+        }
+        return this;
+    }
+
+	/**
+	 * Verifies that the passed in user object must be the same as the authenticated user.
+	 * Equality is done by evaluating the `getid()` method on both objects.
+	 * If the equality check fails, a `NotAuthorized` exception is thrown.
+	 *
+	 * @throws NoUserLoggedIn
+	 * @throws NotAuthorized
+	 *
+	 * @user The user to test for equality
+	 * @message The error message to throw in the exception
+	 */
+	CBSecurity function secureSameUser(
+		required user,
+		message = variables.DEFAULT_ERROR_MESSAGE
+	){
+		if ( !sameUser( arguments.user ) ) {
+			throw(
+				type    = "NotAuthorized",
+				message = arguments.message
+			);
 		}
 		return this;
-	}
+    }
 
 	/**
 	 * Alias proxy if somebody is coming from cbguard, proxies to the secure() method

--- a/test-harness/tests/specs/unit/CBSecurityTest.cfc
+++ b/test-harness/tests/specs/unit/CBSecurityTest.cfc
@@ -301,6 +301,22 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbsecurity.model
 						cbsecurity.secureWhen( function( user ){ return false; } );
 					});
 				});
+				describe( "secureSameUser() method", function(){
+					it( "can secure if the logged in user is not the user passed", function(){
+                        mockUser.$( "getId", 1 );
+                        var testUser = createStub().$( "getId", 2 );
+
+						expect( function(){
+							cbsecurity.secureSameUser( testUser );
+						}).toThrow( "NotAuthorized" );
+					});
+
+					it( "can allow if the logged in user is the user passed", function(){
+                        mockUser.$( "getId", 1 );
+                        var testUser = createStub().$( "getId", 1 );
+						cbsecurity.secureSameUser( testUser );
+					});
+				});
 			});
 
 		});


### PR DESCRIPTION
Just as `sameUser` returns `false` when the passed in user is different than the logged in user, `secureSameUser` will throw when the passed in user is different than the logged in user.