### PR TITLE
Try to auto refresh on invalid and missing tokens as well

### DIFF
--- a/models/jwt/JwtService.cfc
+++ b/models/jwt/JwtService.cfc
@@ -895,41 +895,60 @@ component accessors="true" singleton threadsafe {
 		};
 
 		try {
-			// Try to get the payload from the jwt token, if we have exceptions, we have failed :(
-			// This takes care of authenticating the jwt tokens for us.
-			// getPayload() => parseToken() => authenticateToken()
-			var payload = getPayload();
+			try {
+				// Try to get the payload from the jwt token, if we have exceptions, we have failed :(
+				// This takes care of authenticating the jwt tokens for us.
+				// getPayload() => parseToken() => authenticateToken()
+				var payload = getPayload();
+			}
+			// Access Token Has Expired
+			catch ( TokenExpiredException e ) {
+				// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
+				if (
+					variables.settings.jwt.enableAutoRefreshValidator && len(
+						discoverRefreshToken()
+					)
+				) {
+					autoRefreshTokens();
+				} else {
+					// Error out as normal
+					results.messages = e.type & ":" & e.message;
+					return results;
+				}
+			} catch ( TokenInvalidException e ) {
+				// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
+				if (
+					variables.settings.jwt.enableAutoRefreshValidator && len(
+						discoverRefreshToken()
+					)
+				) {
+					autoRefreshTokens();
+				} else {
+					// Error out as normal
+					results.messages = e.type & ":" & e.message;
+					return results;
+				}
+			} catch ( TokenNotFoundException e ) {
+				// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
+				if (
+					variables.settings.jwt.enableAutoRefreshValidator && len(
+						discoverRefreshToken()
+					)
+				) {
+					autoRefreshTokens();
+				} else {
+					// Error out as normal
+					results.messages = e.type & ":" & e.message;
+					return results;
+				}
+			}
+			// All other exceptions
+			catch ( Any e ) {
+				results.messages = e.type & ":" & e.message;
+				return results;
+			}
 		}
-		// Access Token Has Expired
-		catch ( TokenExpiredException e ) {
-			// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
-			if ( variables.settings.jwt.enableAutoRefreshValidator && len( discoverRefreshToken() ) ) {
-				autoRefreshTokens();
-			} else {
-				// Error out as normal
-				results.messages = e.type & ":" & e.message;
-				return results;
-			}
-		} catch ( TokenInvalidException e ) {
-			// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
-			if ( variables.settings.jwt.enableAutoRefreshValidator && len( discoverRefreshToken() ) ) {
-				autoRefreshTokens();
-			} else {
-				// Error out as normal
-				results.messages = e.type & ":" & e.message;
-				return results;
-			}
-		} catch ( TokenNotFoundException e ) {
-			// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
-			if ( variables.settings.jwt.enableAutoRefreshValidator && len( discoverRefreshToken() ) ) {
-				autoRefreshTokens();
-			} else {
-				// Error out as normal
-				results.messages = e.type & ":" & e.message;
-				return results;
-			}
-		}
-		// All other exceptions
+		// All exceptions for refreshTokens
 		catch ( Any e ) {
 			results.messages = e.type & ":" & e.message;
 			return results;

--- a/models/jwt/JwtService.cfc
+++ b/models/jwt/JwtService.cfc
@@ -910,8 +910,7 @@ component accessors="true" singleton threadsafe {
 				results.messages = e.type & ":" & e.message;
 				return results;
 			}
-		}
-		catch ( TokenInvalidException e ) {
+		} catch ( TokenInvalidException e ) {
 			// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
 			if ( variables.settings.jwt.enableAutoRefreshValidator && len( discoverRefreshToken() ) ) {
 				autoRefreshTokens();
@@ -920,8 +919,7 @@ component accessors="true" singleton threadsafe {
 				results.messages = e.type & ":" & e.message;
 				return results;
 			}
-		}
-		catch ( TokenNotFoundException e ) {
+		} catch ( TokenNotFoundException e ) {
 			// Do we have autoRefreshValidator turned on and we have an incoming refresh token?
 			if ( variables.settings.jwt.enableAutoRefreshValidator && len( discoverRefreshToken() ) ) {
 				autoRefreshTokens();
@@ -957,7 +955,7 @@ component accessors="true" singleton threadsafe {
 		return results;
 	}
 
-	private function autoRefreshTokens() {
+	private function autoRefreshTokens(){
 		// Try to Refresh the tokens
 		var newTokens = this.refreshToken( discoverRefreshToken() );
 		// Setup payload + authenticate for current request

--- a/models/jwt/JwtService.cfc
+++ b/models/jwt/JwtService.cfc
@@ -909,9 +909,7 @@ component accessors="true" singleton threadsafe {
 					!variables.settings.jwt.enableAutoRefreshValidator ||
 					!len( refreshToken ) ||
 					!listFindNoCase(
-						"TokenExpiredException",
-						"TokenInvalidException",
-						"TokenNotFoundException",
+						"TokenExpiredException,TokenInvalidException,TokenNotFoundException",
 						e.type
 					)
 				) {

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -64,6 +64,17 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 							expect( results.messages ).toInclude( "TokenNotFoundException" );
 						} );
 					} );
+					given( "Auto refresh is on and no access token is sent but a refresh token is sent", function(){
+						then( "the validation should pass and we should return our two new tokens as headers", function(){
+							var oUser  = variables.userService.retrieveUserByUsername( "test" );
+							var tokens = variables.jwtService.fromUser( oUser );
+
+							getRequestContext().setValue( "x-refresh-token", tokens.refresh_token );
+
+							var results = variables.jwtService.validateSecurity( "" );
+							expect( results.allow ).toBeTrue();
+						} );
+					} );
 					given( "Auto refresh is on and an expired access token is sent but no refresh token is sent", function(){
 						then( "the validation should fail", function(){
 							getRequestContext().setValue( "x-auth-token", variables.expired_token );

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -95,6 +95,18 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 							expect( results.allow ).toBeTrue();
 						} );
 					} );
+					given( "Auto refresh is on and an expired access token is sent with an expired refresh token", function(){
+						then( "the validation should fail", function(){
+							getRequestContext().setValue( "x-auth-token", variables.expired_token );
+							getRequestContext().setValue(
+								"x-refresh-token",
+								variables.expired_token
+							);
+
+							var results = variables.jwtService.validateSecurity( "" );
+							expect( results.allow ).toBeFalse();
+						} );
+					} );
 				} );
 
 				story( "I can refresh tokens via the /refreshtoken endpoint", function(){


### PR DESCRIPTION
Instead of only trying to auto refresh if the token is expired, also try when the token is missing or invalid. Basically, as long as a refresh token is present, try to refresh.