### PR TITLE
Fix token storage, allow for custom refresh token claims, and allow for deferred callback claims

### DIFF
--- a/handlers/Home.cfc
+++ b/handlers/Home.cfc
@@ -64,7 +64,7 @@ component extends="coldbox.system.RestHandler" {
 		} catch ( TokenInvalidException e ) {
 			prc.response.setErrorMessage(
 				"Invalid Token - #e.message#",
-				400,
+				401,
 				"Invalid Token"
 			);
 		} catch ( TokenExpiredException e ) {

--- a/models/jwt/JwtService.cfc
+++ b/models/jwt/JwtService.cfc
@@ -352,6 +352,7 @@ component accessors="true" singleton threadsafe {
 	 *
 	 * @refreshToken A refresh token
 	 * @customClaims A struct of custom claims to apply to the new tokens
+	 * @refreshCustomClaims A struct of custom claims to add to the refresh token
 	 *
 	 * @throws RefreshTokensNotActive If the setting enableRefreshTokens is false
 	 * @throws TokenExpiredException If the token has expired or no longer in the storage (invalidated)
@@ -360,7 +361,11 @@ component accessors="true" singleton threadsafe {
 	 *
 	 * @return A struct of { access_token : "", refresh_token : "" }
 	 */
-	struct function refreshToken( token = discoverRefreshToken(), struct customClaims = {} ){
+	struct function refreshToken(
+		token                      = discoverRefreshToken(),
+		struct customClaims        = {},
+		struct refreshCustomClaims = {}
+	){
 		if ( !variables.settings.jwt.enableRefreshTokens ) {
 			throw(
 				type   : "RefreshTokensNotActive",
@@ -379,7 +384,11 @@ component accessors="true" singleton threadsafe {
 		var oUser = authenticate( payload: payload );
 
 		// Build new tokens according to validated user
-		var results = fromUser( oUser, arguments.customClaims );
+		var results = fromUser(
+			oUser,
+			arguments.customClaims,
+			arguments.refreshCustomClaims
+		);
 
 		// Invalidate the refresh token: Token Rotation
 		invalidate( arguments.token );

--- a/models/jwt/JwtService.cfc
+++ b/models/jwt/JwtService.cfc
@@ -140,7 +140,7 @@ component accessors="true" singleton threadsafe {
 	any function attempt(
 		required username,
 		required password,
-		struct customClaims = {},
+		struct customClaims        = {},
 		struct refreshCustomClaims = {}
 	){
 		// Authenticate via the auth service wired up
@@ -155,7 +155,11 @@ component accessors="true" singleton threadsafe {
 			.setPrivateValue( variables.settings.prcUserVariable, oUser );
 
 		// Create the token(s) and return it
-		return fromUser( oUser, arguments.customClaims, arguments.refreshCustomClaims );
+		return fromUser(
+			oUser,
+			arguments.customClaims,
+			arguments.refreshCustomClaims
+		);
 	}
 
 	/**
@@ -198,10 +202,18 @@ component accessors="true" singleton threadsafe {
 	 *
 	 * @return An access token if the enableRefreshTokens setting is false, else a struct with the access and refresh token: { access_token : "", refresh_token : "" }
 	 */
-	any function fromUser( required user, struct customClaims = {}, struct refreshCustomClaims = {} ){
+	any function fromUser(
+		required user,
+		struct customClaims        = {},
+		struct refreshCustomClaims = {}
+	){
 		// Refresh token and access token
 		if ( variables.settings.jwt.enableRefreshTokens ) {
-			structAppend( arguments.refreshCustomClaims, arguments.customClaims, false );
+			structAppend(
+				arguments.refreshCustomClaims,
+				arguments.customClaims,
+				false
+			);
 			return {
 				"access_token" : generateToken(
 					user        : arguments.user,

--- a/models/jwt/JwtService.cfc
+++ b/models/jwt/JwtService.cfc
@@ -814,6 +814,17 @@ component accessors="true" singleton threadsafe {
 		// Append incoming custom claims with override, they take prescedence
 		structAppend( payload, arguments.customClaims, true );
 
+		for ( var key in payload ) {
+			if ( !structKeyExists( payload, key ) || isNull( payload[ key ] ) ) {
+				continue;
+			}
+
+			if ( isCustomFunction( payload[ key ] ) || isClosure( payload[ key ] ) ) {
+				var fn         = payload[ key ];
+				payload[ key ] = fn( payload );
+			}
+		}
+
 		// Create the token for the user
 		var jwtToken = this.encode( payload );
 

--- a/models/jwt/storages/CacheTokenStorage.cfc
+++ b/models/jwt/storages/CacheTokenStorage.cfc
@@ -67,14 +67,15 @@ component accessors="true" singleton threadsafe {
 		required payload
 	){
 		variables.cache.set(
-			buildKey( arguments.key ),
-			{
+			objectKey = buildKey( arguments.key ),
+			object = {
 				token      : arguments.token,
 				expiration : jwtService.fromEpoch( arguments.payload.exp ),
 				issued     : jwtService.fromEpoch( arguments.payload.iat ),
 				payload    : arguments.payload
 			},
-			arguments.expiration
+			timeout = arguments.expiration,
+			lastAccessTimeout = 0
 		);
 		return this;
 	}

--- a/models/jwt/storages/CacheTokenStorage.cfc
+++ b/models/jwt/storages/CacheTokenStorage.cfc
@@ -68,13 +68,13 @@ component accessors="true" singleton threadsafe {
 	){
 		variables.cache.set(
 			objectKey = buildKey( arguments.key ),
-			object = {
+			object    = {
 				token      : arguments.token,
 				expiration : jwtService.fromEpoch( arguments.payload.exp ),
 				issued     : jwtService.fromEpoch( arguments.payload.iat ),
 				payload    : arguments.payload
 			},
-			timeout = arguments.expiration,
+			timeout           = arguments.expiration,
 			lastAccessTimeout = 0
 		);
 		return this;

--- a/models/jwt/storages/DBTokenStorage.cfc
+++ b/models/jwt/storages/DBTokenStorage.cfc
@@ -293,7 +293,10 @@ component accessors="true" singleton threadsafe {
 			  WHERE cacheKey = ?
 			",
 			[ arguments.key ],
-			{ datasource : variables.properties.dsn, result : "local.q" }
+			{
+				datasource : variables.properties.dsn,
+				result     : "local.q"
+			}
 		);
 
 		return ( local.q.recordCount ? true : false );

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -212,8 +212,8 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 						} );
 					} );
 
-					given( "custom refresh claims on the attempt method", function() {
-						then( "the claims should be passed on to the refresh method", function() {
+					given( "custom refresh claims on the attempt method", function(){
+						then( "the claims should be passed on to the refresh method", function(){
 							var newTokens = variables.jwtService.attempt(
 								"test",
 								"test",

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -269,7 +269,10 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 							var decodedRefreshToken = variables.jwtService.decode(
 								newTokens.refresh_token
 							);
-							expect( decodedRefreshToken ).toHaveKeyWithCase( "bar" );
+
+							// TODO: Change to `toHaveKeyWithCase` when Adobe 2021 Bug is resolved
+							// https://tracker.adobe.com/#/view/CF-4215309
+							expect( decodedRefreshToken ).toHaveKey( "bar" );
 							expect( decodedRefreshToken.bar ).toBe( 4 );
 						} );
 					} );

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -212,6 +212,37 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 						} );
 					} );
 
+					given( "any custom claims with a function or closure", function(){
+						then( "it should evaluate them right before encoding the token", function(){
+							var newTokens = variables.jwtService.attempt(
+								"test",
+								"test",
+								{ "foo" : 2 },
+								{
+									"bar" : function( claims ){
+										return claims.foo * claims.foo;
+									}
+								}
+							);
+
+							expect( newTokens )
+								.toBeStruct()
+								.toHaveKey( "access_token" )
+								.toHaveKey( "refresh_token" );
+
+							var decodedAccessToken = variables.jwtService.decode(
+								newTokens.access_token
+							);
+							expect( decodedAccessToken ).toHaveKey( "foo" );
+							expect( decodedAccessToken.foo ).toBe( 2 );
+							var decodedRefreshToken = variables.jwtService.decode(
+								newTokens.refresh_token
+							);
+							expect( decodedRefreshToken ).toHaveKey( "bar" );
+							expect( decodedRefreshToken.bar ).toBe( 4 );
+						} );
+					} );
+
 					given( "custom refresh claims on the attempt method", function(){
 						then( "the claims should be passed on to the refresh method", function(){
 							var newTokens = variables.jwtService.attempt(

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -6,6 +6,37 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 		clearFrameworks();
 		super.beforeAll();
 
+		addMatchers( {
+			toHaveKeyWithCase : function( expectation, args = {} ){
+				// handle both positional and named arguments
+				param args.key = "";
+				if ( structKeyExists( args, 1 ) ) {
+					args.key = args[ 1 ];
+				}
+				param args.message = "";
+				if ( structKeyExists( args, 2 ) ) {
+					args.message = args[ 2 ];
+				}
+
+				if ( args.key == "" ) {
+					expectation.message = "No Key Provided.";
+					return false;
+				}
+
+				if ( !listFind( expectation.actual.keyList(), args.key ) ) {
+					if ( listFindNoCase( expectation.actual.keyList(), args.key ) ) {
+						expectation.message = "The key(s) [#args.key#] does exist in the target object, but the Case is incorrect. Found keys are [#structKeyArray( expectation.actual ).toString()#]";
+					} else {
+						expectation.message = "The key(s) [#args.key#] does not exist in the target object, with or without case sensitivity. Found keys are [#structKeyArray( expectation.actual ).toString()#]";
+					}
+					debug( expectation.actual );
+					return false;
+				}
+
+				return true;
+			}
+		} );
+
 		// Fixtures
 		variables.expired_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE1NjkyNzI0NjQsInJvbGUiOiJhZG1pbiIsInNjb3BlcyI6W10sImlzcyI6Imh0dHA6Ly8xMjcuMC4wLjE6NTY1OTYvIiwic3ViIjoxMjMsImV4cCI6MTU2OTI3MjQ2NSwianRpIjoiRTRDNEM3MDdFNjA1MzQwRDkxRDNCMDBCMkI4NTdFNDMifQ.N2rT_b_Xp8e9Hw0O7yVork6Fg8aC7RKf0Fv-Bmu7Iv5CVvFrmk1gkF_oKeXmcl22MiwhB2oQJhMNZiFa5OfSKw";
 		variables.invalid_token = "eyJ0eXAiOiJKV1QihbGciOiJIUzUxMiJ9.eyJpYXQiOjE1Njg5MDMyODIsImlzcyI6Imh0dHA6Ly8xMjcuMC4wLjE6NTY1OTYvaW5kZXguY2ZtLyIsInN1YiI6MCwiZXhwIjoxNTY4OTA2ODgyLCJqdGkiOiIzRDUyMjUzNDM3Mjk4NjlCQkUzMjQxRUEzNjVEMUJDMyJ9.aCJrcD4TV0ei9lGpmrn0I2WQLrvSUx64BXPJYVi7BzZ2U-yS5ejg";
@@ -146,8 +177,8 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 							);
 							expect( event.getResponse().getData() )
 								.toBeStruct()
-								.toHaveKey( "access_token" )
-								.toHaveKey( "refresh_token" );
+								.toHaveKeyWithCase( "access_token" )
+								.toHaveKeyWithCase( "refresh_token" );
 						} );
 					} );
 					given( "An activated endpoint and an invalid refresh token", function(){
@@ -175,8 +206,8 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 							);
 							expect( newTokens )
 								.toBeStruct()
-								.toHaveKey( "access_token" )
-								.toHaveKey( "refresh_token" );
+								.toHaveKeyWithCase( "access_token" )
+								.toHaveKeyWithCase( "refresh_token" );
 							expect( variables.jwtService.isTokenInStorage( tokens.refresh_token ) ).toBeFalse();
 							expect(
 								variables.jwtService.isTokenInStorage( newTokens.access_token )
@@ -196,18 +227,18 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 							);
 							expect( newTokens )
 								.toBeStruct()
-								.toHaveKey( "access_token" )
-								.toHaveKey( "refresh_token" );
+								.toHaveKeyWithCase( "access_token" )
+								.toHaveKeyWithCase( "refresh_token" );
 
 							var decodedAccessToken = variables.jwtService.decode(
 								newTokens.access_token
 							);
-							expect( decodedAccessToken ).toHaveKey( "foo" );
+							expect( decodedAccessToken ).toHaveKeyWithCase( "foo" );
 							expect( decodedAccessToken.foo ).toBe( "bar" );
 							var decodedRefreshToken = variables.jwtService.decode(
 								newTokens.refresh_token
 							);
-							expect( decodedRefreshToken ).toHaveKey( "foo" );
+							expect( decodedRefreshToken ).toHaveKeyWithCase( "foo" );
 							expect( decodedRefreshToken.foo ).toBe( "bar" );
 						} );
 					} );
@@ -227,18 +258,18 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 
 							expect( newTokens )
 								.toBeStruct()
-								.toHaveKey( "access_token" )
-								.toHaveKey( "refresh_token" );
+								.toHaveKeyWithCase( "access_token" )
+								.toHaveKeyWithCase( "refresh_token" );
 
 							var decodedAccessToken = variables.jwtService.decode(
 								newTokens.access_token
 							);
-							expect( decodedAccessToken ).toHaveKey( "foo" );
+							expect( decodedAccessToken ).toHaveKeyWithCase( "foo" );
 							expect( decodedAccessToken.foo ).toBe( 2 );
 							var decodedRefreshToken = variables.jwtService.decode(
 								newTokens.refresh_token
 							);
-							expect( decodedRefreshToken ).toHaveKey( "bar" );
+							expect( decodedRefreshToken ).toHaveKeyWithCase( "bar" );
 							expect( decodedRefreshToken.bar ).toBe( 4 );
 						} );
 					} );
@@ -254,18 +285,18 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 
 							expect( newTokens )
 								.toBeStruct()
-								.toHaveKey( "access_token" )
-								.toHaveKey( "refresh_token" );
+								.toHaveKeyWithCase( "access_token" )
+								.toHaveKeyWithCase( "refresh_token" );
 
 							var decodedAccessToken = variables.jwtService.decode(
 								newTokens.access_token
 							);
-							expect( decodedAccessToken ).toHaveKey( "foo" );
+							expect( decodedAccessToken ).toHaveKeyWithCase( "foo" );
 							expect( decodedAccessToken.foo ).toBe( "bar" );
 							var decodedRefreshToken = variables.jwtService.decode(
 								newTokens.refresh_token
 							);
-							expect( decodedRefreshToken ).toHaveKey( "foo" );
+							expect( decodedRefreshToken ).toHaveKeyWithCase( "foo" );
 							expect( decodedRefreshToken.foo ).toBe( "baz" );
 						} );
 					} );
@@ -274,13 +305,13 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 						then( "it should pass the current payload in to the function", function(){
 							var oUser  = variables.userService.retrieveUserByUsername( "test" );
 							var tokens = variables.jwtService.fromUser( oUser );
-							expect( tokens ).toBeStruct().toHaveKey( "access_token" );
+							expect( tokens ).toBeStruct().toHaveKeyWithCase( "access_token" );
 
 							var decodedAccessToken = variables.jwtService.decode(
 								tokens.access_token
 							);
-							expect( decodedAccessToken ).toHaveKey( "jti" );
-							expect( decodedAccessToken ).toHaveKey( "duplicatedJTI" );
+							expect( decodedAccessToken ).toHaveKeyWithCase( "jti" );
+							expect( decodedAccessToken ).toHaveKeyWithCase( "duplicatedJTI" );
 							expect( decodedAccessToken.duplicatedJTI ).toBe(
 								decodedAccessToken.jti
 							);
@@ -310,8 +341,8 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 					var tokens = variables.jwtService.fromUser( oUser );
 					expect( tokens )
 						.toBeStruct()
-						.toHaveKey( "access_token" )
-						.toHaveKey( "refresh_token" );
+						.toHaveKeyWithCase( "access_token" )
+						.toHaveKeyWithCase( "refresh_token" );
 				} );
 
 				it( "can discover refresh tokens via the rc", function(){
@@ -403,7 +434,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 						var tokenStorageSetCallLog = tokenStorageMock.$callLog().set;
 						expect( tokenStorageSetCallLog ).toBeArray();
 						expect( tokenStorageSetCallLog ).toHaveLength( 1 );
-						expect( tokenStorageSetCallLog[ 1 ] ).toHaveKey( "expiration" );
+						expect( tokenStorageSetCallLog[ 1 ] ).toHaveKeyWithCase( "expiration" );
 						expect( tokenStorageSetCallLog[ 1 ].expiration ).toBeCloseTo(
 							expirationSeconds,
 							1

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -212,6 +212,33 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 						} );
 					} );
 
+					given( "custom refresh claims on the attempt method", function() {
+						then( "the claims should be passed on to the refresh method", function() {
+							var newTokens = variables.jwtService.attempt(
+								"test",
+								"test",
+								{ "foo" : "bar" },
+								{ "foo" : "baz" }
+							);
+
+							expect( newTokens )
+								.toBeStruct()
+								.toHaveKey( "access_token" )
+								.toHaveKey( "refresh_token" );
+
+							var decodedAccessToken = variables.jwtService.decode(
+								newTokens.access_token
+							);
+							expect( decodedAccessToken ).toHaveKey( "foo" );
+							expect( decodedAccessToken.foo ).toBe( "bar" );
+							var decodedRefreshToken = variables.jwtService.decode(
+								newTokens.refresh_token
+							);
+							expect( decodedRefreshToken ).toHaveKey( "foo" );
+							expect( decodedRefreshToken.foo ).toBe( "baz" );
+						} );
+					} );
+
 					given( "a getJwtCustomClaims method on user", function(){
 						then( "it should pass the current payload in to the function", function(){
 							var oUser  = variables.userService.retrieveUserByUsername( "test" );

--- a/test-harness/views/main/index.cfm
+++ b/test-harness/views/main/index.cfm
@@ -1,3 +1,4 @@
 <cfoutput>
 <h1>Security</h1>
+<h3>public</h3>
 </cfoutput>


### PR DESCRIPTION
1. Disable lastAccessTimeouts for JWT CacheTokenStorage
2. Allow passing in custom refresh token claims to `attempt` and `fromUser`. This allows for setting keys like custom expiration dates for refresh tokens, when needed.
3. Evaluate functions passed to claims right before encoding passing in the current payload.

