### PR TITLE
🐛 FIX: Update GHA to avoid deprecated syntax

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: taiki-e/create-gh-release-action@v1.5.0
+      - uses: taiki-e/create-gh-release-action@v1.6.1
         with:
           # Produced by the build/Build.cfc
           changelog: changelog.md


### PR DESCRIPTION
The [create-gh-release-action](https://github.com/taiki-e/create-gh-release-action) needs updating to avoid GitHub's deprecated `set-output` syntax.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/