### PR TITLE
parens around top for sql server

### DIFF
--- a/models/util/DBLogger.cfc
+++ b/models/util/DBLogger.cfc
@@ -245,7 +245,7 @@ component accessors="true" singleton threadsafe {
 	private function getLimitStart(){
 		switch ( getDatabaseVendor() ) {
 			case "Microsoft SQL Server": {
-				return " TOP :top ";
+				return " TOP (:top) ";
 			}
 		}
 		return "";


### PR DESCRIPTION
sql server requires parens around "top" in slect statement