### PR TITLE
Proposal to add ability to use CIDR signatures for IP addresses in coldbox rules

### DIFF
--- a/box.json
+++ b/box.json
@@ -25,7 +25,8 @@
     "dependencies":{
         "jwt-cfml":"^1.0.0",
         "cbauth":"^6.0.0",
-        "cbcsrf":"^3.0.0"
+        "cbcsrf":"^3.0.0",
+        "ip":"^1.0.0"
     },
     "devDependencies":{
         "commandbox-cfformat":"*",
@@ -62,6 +63,7 @@
     "installPaths":{
         "jwt-cfml":"modules/jwtcfml/",
         "cbauth":"modules/cbauth/",
-        "cbcsrf":"modules/cbcsrf/"
+        "cbcsrf":"modules/cbcsrf/",
+        "ip":"modules/ip/"
     }
 }

--- a/interceptors/Security.cfc
+++ b/interceptors/Security.cfc
@@ -26,9 +26,6 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 	 * Configure the security firewall
 	 */
 	function configure(){
-		// set ipHelper to not load range
-		ipHelper.setLoadRange( false );
-
 
 		// Shorthand for rules
 		if ( isArray( variables.properties.firewall.rules ) ) {
@@ -846,6 +843,7 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 			return true;
 		}
 
+		ipHelper.setLoadRange(false);
 		var ipRegex = "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
 		var realIp  = variables.cbSecurity.getRealIP();
 		var ipArray = listToArray( ipList ).map( ( v ) => replaceNoCase( v, " ", "", "ALL" ) );

--- a/interceptors/Security.cfc
+++ b/interceptors/Security.cfc
@@ -15,7 +15,7 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 	property name="cbSecurity"          inject="@cbSecurity";
 	property name="invalidEventHandler" inject="coldbox:setting:invalidEventHandler";
 	property name="DBLogger"            inject="DBLogger@cbsecurity";
-	property name="ipHelper"			inject="ip@ip";
+	property name="ipHelper"            inject="ip@ip";
 
 	/**
 	 * The reference to the security validator for this firewall. One-to-One relationship.
@@ -26,8 +26,8 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 	 * Configure the security firewall
 	 */
 	function configure(){
-		//set ipHelper to not load range
-		ipHelper.setLoadRange(false);
+		// set ipHelper to not load range
+		ipHelper.setLoadRange( false );
 
 
 		// Shorthand for rules
@@ -842,23 +842,23 @@ component accessors="true" extends="coldbox.system.Interceptor" {
 	private boolean function isValidIP( required allowedIPs ){
 		var ipList = !len( arguments.allowedIPs ) ? "*" : arguments.allowedIPs;
 
-		if( ipList eq '*' ){
+		if ( ipList eq "*" ) {
 			return true;
 		}
 
-		var ipRegex = '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$';
-		var realIp = variables.cbSecurity.getRealIP();
-		var ipArray = listToArray(ipList).map( (v) => replaceNoCase(v, " ", "", "ALL") );
+		var ipRegex = "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$";
+		var realIp  = variables.cbSecurity.getRealIP();
+		var ipArray = listToArray( ipList ).map( ( v ) => replaceNoCase( v, " ", "", "ALL" ) );
 
-		//find ip address
-		var isIpValid = arrayFind( ipArray, (val) => {
+		// find ip address
+		var isIpValid = arrayFind( ipArray, ( val ) => {
 			// if simple ip
-			if( isValid(type='regex', value=val, pattern=ipRegex) ){
+			if ( isValid( type = "regex", value = val, pattern = ipRegex ) ) {
 				return realIp eq val;
 			} else {
-				return ipHelper.v4(val).isInRange(realIp);
+				return ipHelper.v4( val ).isInRange( realIp );
 			}
-		});
+		} );
 
 		return isIpValid != 0;
 	}

--- a/server-adobe@2021.json
+++ b/server-adobe@2021.json
@@ -5,6 +5,7 @@
         "cfengine":"adobe@2021"
     },
     "web":{
+        "host":"0.0.0.0",
         "http":{
             "port":"60299"
         },
@@ -23,7 +24,7 @@
     "cfconfig":{
         "file":".cfconfig.json"
     },
-	"scripts":{
+    "scripts":{
         "onServerInstall":"cfpm install zip,debugger,mysql"
     }
 }

--- a/server-lucee@5.json
+++ b/server-lucee@5.json
@@ -5,6 +5,7 @@
         "cfengine":"lucee@5"
     },
     "web":{
+        "host":"0.0.0.0",
         "http":{
             "port":"60299"
         },

--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -129,6 +129,16 @@
 							"action"      : "redirect",
 							"allowedIPs"  : "10.0.0.1"
 						},
+						// Match only given ips
+						{
+							"whitelist"   : "",
+							"securelist"  : "iptester",
+							"match"       : "event",
+							"roles"       : "",
+							"permissions" : "",
+							"action"      : "block",
+							"allowedIPs"  : "127.0.0.1, 172.17.1.140, 172.17.2.0/24"
+						},					
 						// no action, use global default action
 						{
 							"whitelist"   : "",

--- a/test-harness/handlers/IPTester.cfc
+++ b/test-harness/handlers/IPTester.cfc
@@ -1,0 +1,24 @@
+/**
+ * I am a new handler
+ */
+component {
+
+	/* 
+		coldbox.cfc rules have been configured with the following ips 
+		127.0.0.1, 
+		172.17.1.140, 
+		172.17.2.0/24" 
+	*/
+
+	function index( event, rc, prc ){
+		event.setView( "IPTester/index" );
+	}
+
+
+
+	function fail( event, rc, prc ){
+		event.setView( "IPTester/fail" );
+	}
+
+
+}

--- a/test-harness/handlers/Main.cfc
+++ b/test-harness/handlers/Main.cfc
@@ -26,7 +26,7 @@ component {
 	function doLogin( event, rc, prc ){
 		try {
 			var oUser = cbsecure().authenticate( rc.username ?: "", rc.password ?: "" );
-			return "You are logged in!";
+			return "You are logged in! Click <a href='/'>here</a> to go back";
 		} catch ( "InvalidCredentials" e ) {
 			flash.put( "message", "Invalid credentials, try again!" );
 			relocate( "main/login" );

--- a/test-harness/layouts/Main.cfm
+++ b/test-harness/layouts/Main.cfm
@@ -1,5 +1,12 @@
 ﻿<cfoutput>
 <h1>Module Tester</h1>
+
+
+<!--- should should be singleton --->
+<cfset cbs = wirebox.getInstance( "cbSecurity@cbSecurity" ) />
+cbSecurity remote IP : #cbs.getRealIP()#<br/>
+You are #cbSecure().isLoggedIn() ? '' : '<span style="color:red">NOT</span>'# logged in 
+
 <div>
 	#renderView()#
 </div>

--- a/test-harness/views/iptester/fail.cfm
+++ b/test-harness/views/iptester/fail.cfm
@@ -1,0 +1,4 @@
+<h4>IP Rule Tester</h4>
+<span style="color:red">Your IP Address was NOT allowed</span>
+<br/><br/>
+<a href="/">Go Back</a>

--- a/test-harness/views/iptester/index.cfm
+++ b/test-harness/views/iptester/index.cfm
@@ -1,0 +1,4 @@
+<h4>IP Rule Tester</h4>
+Your IP Address was allowed
+<br/><br/>
+<a href="/">Go Back</a>

--- a/test-harness/views/main/index.cfm
+++ b/test-harness/views/main/index.cfm
@@ -25,6 +25,9 @@
 		<a href="/putpost">PUT/POST Rejection</a>
 	</li>
 	<li>
+		<a href="/iptester">IP Tester Action</a>
+	</li>	
+	<li>
 		<a href="/noAction">Secure No Action</a>
 	</li>
 	<li>


### PR DESCRIPTION
# Description

I have a need to allow entire subnets access to a particular application. I would like to propose the following changes to allow this. This is fairly a big change due to a new module dependency so would like to hear your thoughts on this.

**Please note that all PRs must have tests attached to them**

tests to follow

## Type of change

I have written and published a new module ( https://forgebox.io/view/ip ) and made changes to cbSecurity to use it so as to allow for CIDR addresses. 

- [x] New Feature

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works 
- [x] New and existing unit tests pass locally with my changes
