### PR TITLE
cbsecurity_logs is hard coded instead of using module setting

### DIFF
--- a/models/util/DBLogger.cfc
+++ b/models/util/DBLogger.cfc
@@ -188,7 +188,7 @@ component accessors="true" singleton threadsafe {
 			"select
 				#getLimitStart()#
 				count( id ) as total, #arguments.column#
-				from cbsecurity_logs
+				from #getTable()#
 				group by #arguments.column#
 				order by count( id ) desc
 				#getLimitEnd()#
@@ -207,8 +207,8 @@ component accessors="true" singleton threadsafe {
 	struct function getActionsReport(){
 		return queryExecute(
 			"select
-			count( id ) as total, action, ( count(id) / ( select count(id) from cbsecurity_logs ) ) * 100 as percentage
-			from cbsecurity_logs
+			count( id ) as total, action, ( count(id) / ( select count(id) from #getTable()# ) ) * 100 as percentage
+			from #getTable()#
 			group by action",
 			{},
 			{ datasource : variables.settings.firewall.logs.dsn }
@@ -230,7 +230,7 @@ component accessors="true" singleton threadsafe {
 	 */
 	struct function getBlockTypesReport(){
 		return queryExecute(
-			"select count( id ) as total, blockType from cbsecurity_logs group by blockType",
+			"select count( id ) as total, blockType from #getTable()# group by blockType",
 			{},
 			{ datasource : variables.settings.firewall.logs.dsn }
 		).reduce( ( results, row ) => {


### PR DESCRIPTION
# Description

The table name is a module setting which is referenced in some but not all places. Replaced hard coded `cbsecurity_logs` references with existing `getTable()` call to be consistent throughout so that the module setting is used when provided.

Issue raised as:
https://ortussolutions.atlassian.net/browse/BOX-141
