### PR TITLE
JWT Handler Response Format Fix

### DIFF
--- a/handlers/Jwt.cfc
+++ b/handlers/Jwt.cfc
@@ -14,13 +14,14 @@ component extends="coldbox.system.RestHandler" {
 	function refreshToken( event, rc, prc ){
 		// If endpoint not enabled, just 404 it
 		if ( !variables.jwtService.getSettings().jwt.enableRefreshEndpoint ) {
-			return event
+			event
 				.getResponse()
 				.setErrorMessage(
 					"Refresh Token Endpoint Disabled",
 					404,
 					"Disabled"
 				);
+			return;
 		}
 
 		try {
@@ -32,9 +33,9 @@ component extends="coldbox.system.RestHandler" {
 				.setData( prc.newTokens )
 				.addMessage( "Tokens refreshed! The passed in refresh token has been invalidated" );
 		} catch ( RefreshTokensNotActive e ) {
-			return event.getResponse().setErrorMessage( "Refresh Tokens Not Active", 404, "Disabled" );
+			event.getResponse().setErrorMessage( "Refresh Tokens Not Active", 404, "Disabled" );
 		} catch ( TokenNotFoundException e ) {
-			return event
+			event
 				.getResponse()
 				.setErrorMessage(
 					"The refresh token was not passed via the header or the rc. Cannot refresh the unrefreshable!",
@@ -42,17 +43,21 @@ component extends="coldbox.system.RestHandler" {
 					"Missing refresh token"
 				);
 		} catch ( TokenInvalidException e ) {
-			prc.response.setErrorMessage(
-				"Invalid Token - #e.message#",
-				401,
-				"Invalid Token"
-			);
+			event
+				.getResponse()
+				.setErrorMessage(
+					"Invalid Token - #e.message#",
+					401,
+					"Invalid Token"
+				);
 		} catch ( TokenExpiredException e ) {
-			prc.response.setErrorMessage(
-				"Token Expired - #e.message#",
-				400,
-				"Token Expired"
-			);
+			event
+				.getResponse()
+				.setErrorMessage(
+					"Token Expired - #e.message#",
+					400,
+					"Token Expired"
+				);
 		}
 	}
 

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -145,6 +145,15 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 								404,
 								event.getResponse().getMessagesString()
 							);
+
+							// Matches the ColdBox RestHandler default response format spec
+							var jsonResponse = deserializeJSON( event.getRenderedContent() );
+							expect( jsonResponse ).toHaveLength( 4 );
+							expect( jsonResponse ).toHaveKey( "data" );
+							expect( jsonResponse ).toHaveKey( "error" );
+							expect( jsonResponse ).toHaveKey( "pagination" );
+							expect( jsonResponse ).toHaveKey( "messages" );
+							expect( jsonResponse.messages[ 1 ] ).toBe( event.getResponse().getMessagesString() );
 						} );
 					} );
 					given( "An activated endpoint but no refresh tokens passed", function(){


### PR DESCRIPTION
# Description

Currently, the JWT Handler improperly returns a value causing it to skip ColdBox's RestHandler's response formatting logic. This results in the entire response object being returned rather than just invoking getDataPacket()


```
coldbox/system/RestHandler.cfc

**Line 58**
// Execute action
var actionResults = arguments.targetAction( argumentCollection = actionArgs );

**Lines 117-142**
// Did the controllers set a view to be rendered? If not use renderdata, else just delegate to view.
 if (
  isNull( local.actionResults )     <- actionResults is set to the result of the handler
  AND
  !arguments.event.getCurrentView().len()
  AND
  arguments.event.getRenderData().isEmpty()
  ) {
  // Get response data according to error flag
  var responseData = (
  arguments.prc.response.getError() ? arguments.prc.response.getDataPacket(
	  reset = this.resetDataOnError
  ) : arguments.prc.response.getDataPacket()
  );
  
  // Magical renderings
  event.renderData(
  type         = arguments.prc.response.getFormat(),
  data         = responseData,
  contentType  = arguments.prc.response.getContentType(),
  statusCode   = arguments.prc.response.getStatusCode(),
  location     = arguments.prc.response.getLocation(),
  isBinary     = arguments.prc.response.getBinary(),
  jsonCallback = arguments.prc.response.getJsonCallback()
  );
}
```


### Before:
`
{
    "STATUS_TEXTS": {
        "300": "Multiple Choices",
        "503": "Service Unavailable",
        "101": "Switching Protocols",
        "406": "Not Acceptable",
        "207": "Multi-Status",
        "424": "Failed Dependency",
        "203": "Non-authoritative Information",
        "410": "Gone",
        "502": "Bad Gateway",
        "508": "Loop Detected",
        "308": "Permanent Redirect",
        "403": "Forbidden",
        "400": "Bad Request",
        "444": "Connection Closed Without Response",
        "599": "Network Connect Timeout Error",
        "506": "Variant Also Negotiates",
        "404": "Not Found",
        "102": "Processing",
        "202": "Accepted",
        "431": "Request Header Fields Too Large",
        "412": "Precondition Failed",
        "510": "Not Extended",
        "418": "I'm a teapot",
        "411": "Length Required",
        "421": "Misdirected Request",
        "304": "Not Modified",
        "208": "Already Reported",
        "226": "IM Used",
        "428": "Precondition Required",
        "302": "Found",
        "416": "Requested Range Not Satisfiable",
        "204": "No Content",
        "501": "Not Implemented",
        "100": "Continue",
        "429": "Too Many Requests",
        "305": "Use Proxy",
        "402": "Payment Required",
        "303": "See Other",
        "200": "OK",
        "499": "Client Closed Request",
        "417": "Expectation Failed",
        "401": "Unauthorized",
        "423": "Locked",
        "505": "HTTP Version Not Supported",
        "205": "Reset Content",
        "405": "Method Not Allowed",
        "451": "Unavailable For Legal Reasons",
        "408": "Request Timeout",
        "413": "Payload Too Large",
        "307": "Temporary Redirect",
        "504": "Gateway Timeout",
        "407": "Proxy Authentication Required",
        "206": "Partial Content",
        "422": "Unprocessable Entity",
        "409": "Conflict",
        "500": "Internal Server Error",
        "426": "Upgrade Required",
        "301": "Moved Permanently",
        "414": "Request-URI Too Long",
        "201": "Created",
        "511": "Network Authentication Required",
        "507": "Insufficient Storage",
        "415": "Unsupported Media Type"
    },
    "$wbMixer": true,
    "hasData": false,
    "hasPagination": false,
    "format": "json",
    "data": {},
    "pagination": {
        "totalPages": 1,
        "maxRows": 0,
        "offset": 0,
        "page": 1,
        "totalRecords": 0
    },
    "error": true,
    "binary": false,
    "messages": [
        "Refresh Token Endpoint Disabled"
    ],
    "location": "",
    "jsonCallback": "",
    "contentType": "",
    "statusCode": 404,
    "statusText": "Ok",
    "responsetime": 0,
    "headers": [
        {
            "name": "x-response-time",
            "value": 0
        }
    ]
}
`

### After:
`
{
    "error": true,
    "messages": [
        "Refresh Token Endpoint Disabled"
    ]
}
`

I updated the test to validate the rendered content returned


## Issues


## Type of change

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
