### PR TITLE
JWT Handler Add missing TokenRejectionException

### DIFF
--- a/handlers/Jwt.cfc
+++ b/handlers/Jwt.cfc
@@ -14,13 +14,7 @@ component extends="coldbox.system.RestHandler" {
 	function refreshToken( event, rc, prc ){
 		// If endpoint not enabled, just 404 it
 		if ( !variables.jwtService.getSettings().jwt.enableRefreshEndpoint ) {
-			event
-				.getResponse()
-				.setErrorMessage(
-					"Refresh Token Endpoint Disabled",
-					404,
-					"Disabled"
-				);
+			event.getResponse().setErrorMessage( "Refresh Token Endpoint Disabled", 404 );
 			return;
 		}
 
@@ -33,31 +27,20 @@ component extends="coldbox.system.RestHandler" {
 				.setData( prc.newTokens )
 				.addMessage( "Tokens refreshed! The passed in refresh token has been invalidated" );
 		} catch ( RefreshTokensNotActive e ) {
-			event.getResponse().setErrorMessage( "Refresh Tokens Not Active", 404, "Disabled" );
+			event.getResponse().setErrorMessage( "Refresh Tokens Not Active", 404 );
 		} catch ( TokenNotFoundException e ) {
 			event
 				.getResponse()
 				.setErrorMessage(
 					"The refresh token was not passed via the header or the rc. Cannot refresh the unrefreshable!",
-					400,
-					"Missing refresh token"
+					400
 				);
 		} catch ( TokenInvalidException e ) {
-			event
-				.getResponse()
-				.setErrorMessage(
-					"Invalid Token - #e.message#",
-					401,
-					"Invalid Token"
-				);
+			event.getResponse().setErrorMessage( "Invalid Token", 401 );
 		} catch ( TokenExpiredException e ) {
-			event
-				.getResponse()
-				.setErrorMessage(
-					"Token Expired - #e.message#",
-					400,
-					"Token Expired"
-				);
+			event.getResponse().setErrorMessage( "Token Expired", 400 );
+		} catch ( TokenRejectionException e ) {
+			event.getResponse().setErrorMessage( "Invalid Token", 401 );
 		}
 	}
 

--- a/test-harness/tests/specs/integration/JWTSpec.cfc
+++ b/test-harness/tests/specs/integration/JWTSpec.cfc
@@ -188,11 +188,21 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 					} );
 					given( "An activated endpoint and an invalid refresh token", function(){
 						then( "it should kick me out", function(){
+							var oUser  = variables.userService.retrieveUserByUsername( "test" );
+							var tokens = variables.jwtService.fromUser( oUser );
 							variables.jwtService.getSettings().jwt.enableRefreshEndpoint = true;
+
+							// Force invalidate the refresh token
+							variables.jwtService.invalidate( tokens.refresh_token );
+
 							var event = this.post(
 								"/cbsecurity/refreshtoken",
-								{ "x-refresh-token" : variables.invalid_token }
+								{ "x-refresh-token" : tokens.refresh_token }
 							);
+
+							var jsonResponse = deserializeJSON( event.getRenderedContent() );
+							expect( jsonResponse.messages[ 1 ] ).toBe( event.getResponse().getMessagesString() );
+
 							expect( event.getResponse().getStatusCode() ).toBe(
 								401,
 								event.getResponse().getMessagesString()


### PR DESCRIPTION
# Description

The JWT refresh token handler was not catching the `TokenRejectionException` thrown in `jwtService.parseToken()`

Updated the setErrorMessage calls to match the latest spec 
`Response function setErrorMessage( required errorMessage, statusCode )`

Updated the actual error messages to not returned detailed response. Sometimes, this goes into too much detail, which could be a potential security risk exposing more information than necessary. Maybe this could use the Coldbox `inDebugMode()` flag to check and add this, but I'm not sure how to wire that up properly at this moment.

## Type of change

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
