### PR TITLE
ACF Compat: Fix dateTimeFormat usage for logDate

### DIFF
--- a/views/home/tabs/activity.cfm
+++ b/views/home/tabs/activity.cfm
@@ -503,7 +503,7 @@
 					<tr>
 						<td>
 							<small class="text-muted">
-								#dateTimeFormat( prc.logs.logDate.toString(), "dd MMM, YYYY HH:mm:ss z" )#
+								#dateTimeFormat( prc.logs.logDate, "dd MMM, YYYY HH:mm:ss z" )#
 							</small>
 						</td>
 						<td>


### PR DESCRIPTION
Will generate an error in ACF: _"coldfusion.sql.QueryColumn@4e0968bf cannot be converted to a date."_  You don't need the `toString()` here.

## Issues

I don't see a Jira board for cbSecurity.

## Type of change

- [ x] Bug Fix
